### PR TITLE
Changed -json option to -j

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nuclei - Burp Extension 
 
-Simple extension that allows to run nuclei scanner directly from burp and transforms json results into the issues.
+Simple extension that allows to run nuclei scanner directly from burp and transforms json results into the issues.  
 ⚠️ Works with nuclei version => v2.9.1.
 
 # Installation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Nuclei - Burp Extension 
 
 Simple extension that allows to run nuclei scanner directly from burp and transforms json results into the issues.
+⚠️ Works with nuclei version => v2.9.1.
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Nuclei - Burp Extension 
 
 Simple extension that allows to run nuclei scanner directly from burp and transforms json results into the issues.  
-⚠️ Works with nuclei version => v2.9.1.
+⚠️ Works with nuclei version >= v2.9.1.
 
 # Installation
 

--- a/nuclei-extension.py
+++ b/nuclei-extension.py
@@ -198,7 +198,7 @@ class BurpExtender(IBurpExtender, ITab, IScanIssue, IExtensionStateListener):
         self.scanResultsTab.add(tabActionPanel, BorderLayout.PAGE_START)
         self.tabPane.addTab(title,self.scanResultsTab)
         
-        cmd = "'" + self.nucleiPathField.text + "' -u " + url + " -t '" + self.nucleiTemplatesPathField.text + "' -json -nc " + self.nucleiCustomArgsField.text
+        cmd = "'" + self.nucleiPathField.text + "' -u " + url + " -t '" + self.nucleiTemplatesPathField.text + "' -j -nc " + self.nucleiCustomArgsField.text
         
         text += "Scanning of " + url + " started<br>" + cmd + "<br>"
         text += "-----------------------------------------------------------<br>"

--- a/nuclei-extension.py
+++ b/nuclei-extension.py
@@ -82,7 +82,7 @@ class BurpExtender(IBurpExtender, ITab, IScanIssue, IExtensionStateListener):
 
         
         self.configPanel.add(Box.createRigidArea(Dimension(0, 10)))
-        self.labelTest = JLabel("Path to nuclei binary:")
+        self.labelTest = JLabel("Path to nuclei binary >= v2.9.1:")
         self.labelTest.setAlignmentX(Component.LEFT_ALIGNMENT)
         self.configPanel.add(self.labelTest)
         


### PR DESCRIPTION
nuclei as of v2.9.1 changed -json option to -j, -jsonl
The information about supported version of nuclei has been also added to extension GUI "Path to nuclei binary >= v2.9.1:"